### PR TITLE
Switch AscertainedForParsimonyUninformativeFilteredAlignment to spec FilteredAlignment

### DIFF
--- a/src/main/java/morphmodels/evolution/alignment/AscertainedForParsimonyUninformativeFilteredAlignment.java
+++ b/src/main/java/morphmodels/evolution/alignment/AscertainedForParsimonyUninformativeFilteredAlignment.java
@@ -1,7 +1,7 @@
 package morphmodels.evolution.alignment;
 
 import beast.base.core.Input;
-import beast.base.evolution.alignment.FilteredAlignment;
+import beast.base.spec.evolution.alignment.FilteredAlignment;
 
 import java.util.HashSet;
 import java.util.Set;


### PR DESCRIPTION
## Summary

`beast.base.evolution.alignment.FilteredAlignment` is `@Deprecated` in beast3 with a Javadoc pointer to `beast.base.spec.evolution.alignment.FilteredAlignment`. This was the only remaining Java migration item for `morph-models` — surfaced by the [beast3-migration](https://github.com/CompEvol/beast3-migration) analyzer.

The spec `FilteredAlignment` still extends the (non-deprecated) `Alignment`, so all the inherited fields the existing override relies on — `isAscertainedInput`, `excludefromInput`, `excludetoInput`, `setupAscertainment()` — remain available unchanged. Only the import and `extends` clause needed updating; one line of real change.

## Test plan

- [x] `mvn test` — 8/8 pass (`LewisMKTest`)
- [x] `mvn -q -DskipTests compile` and `test-compile` — clean
- [ ] Maintainer to verify the example XMLs still run (the migration's behaviour for ascertainment correction relies on the inherited setup, which spec `FilteredAlignment` preserves)